### PR TITLE
Add installation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,25 @@
 
 Bash script utility for running secure copy of a file in chunks in parallel.
 
+## Installation
+
+From your favorite terminal, run:
+
+```
+curl -s https://raw.githubusercontent.com/yinonavraham/pscp/master/install.sh | bash
+```
+
 ## Usage
 
 ```
-pscp.sh [OPTIONS] FILE DEST
+pscp [OPTIONS] FILE DEST
 ```
 
 ### Example
 
 In order to copy a local file named `myfile` to path `/path/to/` in a remote host named `some-other-host`, authenticating as `myuser` (based on SSH key), use:
 ```
-pscp.sh myfile myuser@some-other-host:/path/to/
+pscp myfile myuser@some-other-host:/path/to/
 ```
 
 ### Basic Options
@@ -46,8 +54,8 @@ The script performs the following main operations:
 
 This script started as an experiment. 
 As part of the experiment files of various sizes were copied between AWS instances, from Frankfurt DE to Oregon US.
-The same files were copied 10 times using `scp` (i.e. single process) and 10 times using `pscp.sh` with default parallelism (i.e. 10 parallel `scp` processes, each transfers a single chunk).
-The results, as can be seen below, transfer time in parallel (using `pscp.sh`) is approximately 30%-40% of the time compared to using `scp`.
+The same files were copied 10 times using `scp` (i.e. single process) and 10 times using `pscp` with default parallelism (i.e. 10 parallel `scp` processes, each transfers a single chunk).
+The results, as can be seen below, transfer time in parallel (using `pscp`) is approximately 30%-40% of the time compared to using `scp`.
 
 ![Average Transfer Time vs. Size](assets/avg_transfer_time.png)  
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -e
+
+echo "Installing pscp..."
+
+if [[ -f /usr/local/bin/pscp ]]; then
+  echo "pscp already installed!"
+  exit 1
+fi
+
+if [[ ! -d /usr/local/bin ]]; then
+  mkdir -p /usr/local/bin
+fi
+
+mkdir -p /usr/local/bin/pscp.d
+
+curl -fsSL https://raw.githubusercontent.com/yinonavraham/pscp/master/pscp.sh -o /usr/local/bin/pscp.d/pscp.sh
+chmod +x /usr/local/bin/pscp.d/pscp.sh
+
+ln -s /usr/local/bin/pscp.d/pscp.sh /usr/local/bin/pscp
+
+if [[ "$(which pscp)" == '' ]]; then
+  echo "pscp installation failed!"
+  exit 1
+fi
+
+echo "Installation finished successfully. Use pscp --help for usage information."


### PR DESCRIPTION
Added an installation script which can be used to install the `pscp` utility. This simplifies the usage of the script.

**Details:**
The `pscp.sh` script is downloaded and saved under directory: `/usr/local/bin/pscp.d` (which is created).
A symbolic link is created: `/usr/local/bin/pscp`.